### PR TITLE
MSVC 64bit support

### DIFF
--- a/dota2MemComm/dota2comm.cpp
+++ b/dota2MemComm/dota2comm.cpp
@@ -225,8 +225,12 @@ DLLEXPORT int init()
 		phandle = 0;
 		return CANT_FIND_PROCESS;
 	}
-	else if (pid < 0)
-		return -pid;
+    /*
+    //DWORD can't be less than 0
+    else if (pid < 0)
+        return -pid;
+    */
+	
 		
 	// open it with some right
 	phandle = OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_INFORMATION, 0, pid);

--- a/dota2MemComm/dota2comm.h
+++ b/dota2MemComm/dota2comm.h
@@ -13,13 +13,26 @@ struct Cell
 	int tt;
 };
 
+/*
 struct MTable
 {
-	void *garbage1, *garbage2;
-	Cell *array;
-	void *garbage3, *garbage4, *garbage5, *garbage6;
-	int arraysize;
+void *garbage1, *garbage2;
+Cell *array;
+void *garbage3, *garbage4, *garbage5, *garbage6;
+int arraysize;
 };
+*/
+
+//int is always 32-bit 
+//pointers are 64-bit in MSVC x86
+struct MTable
+{
+    int garbage1, garbage2;
+    int array;
+    int garbage3, garbage4, garbage5, garbage6;
+    int arraysize;
+};
+
 
 struct Table
 {


### PR DESCRIPTION
I used int to replace the pointers in the header

tested on VS2015 x86/x64,python3.5.2-win32/amd64 and dota2 64bits.