### PR TITLE
multi bot supports and memory leak fix.

### DIFF
--- a/dota2MemComm/dota2comm.h
+++ b/dota2MemComm/dota2comm.h
@@ -32,7 +32,8 @@ struct Table
 	int32_t input_ptr, output_ptr;
 };
 
-DLLEXPORT const char *receiveMessage();
-DLLEXPORT bool sendMessage(const char *text);
-DLLEXPORT int init();
-DLLEXPORT int getNrConnectedClients();
+DLLEXPORT const char *receiveMessage(const char *marker);
+DLLEXPORT bool sendMessage(const char *marker, const char *text);
+DLLEXPORT int init(const char *marker);
+DLLEXPORT int getNrConnectedClients(const char *marker);
+DLLEXPORT void freeString(const char *str);

--- a/dota2MemComm/dota2comm.lua
+++ b/dota2MemComm/dota2comm.lua
@@ -1,57 +1,72 @@
-module("comm", package.seeall)
+local comm = {}
 
-local input = {};
-local output = {};
+local function add_marker(s,marker)
+    return s..marker
+	--return s
+end
+
+function comm:new(marker)
+	print("comm init " .. marker)
+
+	local o = {}
+
+	setmetatable(o, self)
+	self.__index = self
 	
-local blank = string.rep(" ", 2^10);
-
-setfenv(1, comm);
-
-function init()
-	print("comm init");
+	local input = {}
+    local output = {}
 	
-	input[0] = "is000"; -- buffer start
-	input[1] = "ie000"; -- buffer end
+    local blank = string.rep(" ", 2^10)
+
+	local r_marker = string.reverse(marker)
+	
+	input[0] = add_marker("is000",r_marker); -- buffer start
+	input[1] = add_marker("ie000",r_marker); -- buffer end
 	for i = 1,10 do
-		input[2-1+i] = "i"..string.format("%03d", i-1)..blank -- buffer...
+		input[2-1+i] = add_marker("i"..string.format("%03d", i-1)..blank,r_marker) -- buffer...
 	end
 	
-	output[0] = "os000" -- buffer start
-	output[1] = "oe000" -- buffer end
+	output[0] = add_marker("os000",r_marker) -- buffer start
+	output[1] = add_marker("oe000",r_marker) -- buffer end
 	for i = 1,10 do
-		output[2-1+i] = ""
+		output[2-1+i] = add_marker("",r_marker)
 	end
 	
 	local tbl = {};
-	
-	local marker = "commtable"
 	
 	tbl[0] = marker;
 	tbl[1] = input;
 	tbl[2] = output;
 	
-	comm[marker..marker] = tbl;
+	o[marker..marker] = tbl;
+	o.r_marker = r_marker
+	return o
 end
 
-function comm.send(text)
-	local b_start = tonumber(string.sub(output[0], 3))
-    local b_end = tonumber(string.sub(output[1], 3))
-	output[2+b_end] = text
+function comm:send(text)
+    local marker = string.reverse( self.r_marker )
+	local markermarker = marker..marker
+	local b_start = tonumber(string.sub(self[markermarker][2][0], 3, 5))
+    local b_end = tonumber(string.sub(self[markermarker][2][1], 3, 5))
+	self[markermarker][2][2+b_end] = add_marker(text,self.r_marker)
 	b_end = (b_end+1)%10
 	if b_end == b_start then error("send buffer is full") end
-	output[1] = "oe"..string.format("%03d", b_end)
+	self[markermarker][2][1] = add_marker("oe"..string.format("%03d", b_end),self.r_marker)
 end
 
-function comm.receive()
-	local b_start = tonumber(string.sub(input[0], 3))
-    local b_end = tonumber(string.sub(input[1], 3))
+function comm:receive()
+	local marker = string.reverse( self.r_marker )
+	local markermarker = marker..marker
+    local blank = string.rep(" ", 2^10)
+	local b_start = tonumber(string.sub(self[markermarker][1][0], 3, 5))
+    local b_end = tonumber(string.sub(self[markermarker][1][1], 3, 5))
 	if b_start == b_end then return nil end
-	local msg = input[2+b_start]
-	input[0] = "is"..string.format("%03d", (b_start+1)%10)
-	input[2+b_start] = "i"..string.format("%03d", b_start)..blank
+	local msg = self[markermarker][1][2+b_start]
+	self[markermarker][1][0] = add_marker("is"..string.format("%03d", (b_start+1)%10), self.r_marker)
+	self[markermarker][1][2+b_start] = add_marker("i"..string.format("%03d", b_start)..blank, self.r_marker)
 	local length = tonumber(string.sub(msg, 2, 4))
 	msg = string.sub(msg, 5, 5-1+length)
 	return msg
 end
 
-init();
+return comm

--- a/dota2MemComm/dota2comm.py
+++ b/dota2MemComm/dota2comm.py
@@ -1,35 +1,45 @@
 import sys
-from ctypes import cdll, c_char_p
+from ctypes import cdll, c_char_p, c_void_p, cast
 
 
 class Dota2Comm:
-    def __init__(self, **kwargs):
+    def __init__(self, name):
         self.__dota2comm = cdll.LoadLibrary("dota2comm.dll")
+        self.name = name
+        self.__name = name.encode()
         
         self.__receiveMessage = self.__dota2comm.receiveMessage
-        self.__receiveMessage.restype = c_char_p
+        self.__receiveMessage.argtypes = [c_char_p]
+        self.__receiveMessage.restype = c_void_p
 
         self.__sendMessage = self.__dota2comm.sendMessage
-        self.__sendMessage.argtypes = [c_char_p]
+        self.__sendMessage.argtypes = [c_char_p, c_char_p]
 
-        err = self.__dota2comm.init()
+        self.__freeString = self.__dota2comm.freeString
+        self.__freeString.argtypes = [c_void_p]
+
+        err = self.__dota2comm.init(self.__name)
         if err != 0:
             raise Exception("init failed! error code %d" % err)
             
-        nrofclients = self.__dota2comm.getNrConnectedClients()
+        nrofclients = self.__dota2comm.getNrConnectedClients(self.__name)
         
         if nrofclients < 1:
             raise Exception("No clients found. Did the game start?")
 
     def receiveMessage(self):
-        msg = self.__receiveMessage()
+        msg = self.__receiveMessage(self.__name)
+        
         if msg is None:
             return None
         else:
-            return msg.decode()
+            ptr = msg
+            msg = cast(msg, c_char_p).value
+            self.__freeString(ptr)
+            return msg.decode()[:-len(self.name)]#removing r_marker
 
     def sendMessage(self, message):
-        return self.__sendMessage(message.encode())
+        return self.__sendMessage(self.__name, message.encode())
         
     def exit(self):
         pass

--- a/interactiveConsole/README.md
+++ b/interactiveConsole/README.md
@@ -12,7 +12,7 @@ Put `interactiveConsole.py` somewhere, together with `dota2comm.py` and the comp
 
 Start a lobby game with the bots.
 
-Run `python3 interactiveConsole.py` and start typing some stuff.
+Run `python3 interactiveConsole.py "name of your client"` and start typing some stuff.
 
 #### File backend
 
@@ -31,6 +31,4 @@ Exit with `exit` to make sure it exits gracefully
 
 (Using the memory backend)
 
-![console](../../images/console.png)
-
-![game](../../images/dota_lina.jpg)
+![game](../../images/dota2_comm_multi_bots.png)

--- a/interactiveConsole/bots/bot_mirana.lua
+++ b/interactiveConsole/bots/bot_mirana.lua
@@ -1,7 +1,7 @@
 local interactiveConsole = require(GetScriptDirectory().."/interactiveConsole")
 
-local linaConsole = interactiveConsole:new("linaConsole")
+local miranaConsole = interactiveConsole:new("miranaConsole")
 
 function Think()
-    linaConsole:execute()
+    miranaConsole:execute()
 end

--- a/interactiveConsole/bots/bot_sven.lua
+++ b/interactiveConsole/bots/bot_sven.lua
@@ -1,7 +1,7 @@
 local interactiveConsole = require(GetScriptDirectory().."/interactiveConsole")
 
-local linaConsole = interactiveConsole:new("linaConsole")
+local svenConsole = interactiveConsole:new("svenConsole")
 
 function Think()
-    linaConsole:execute()
+    svenConsole:execute()
 end

--- a/interactiveConsole/bots/interactiveConsole.lua
+++ b/interactiveConsole/bots/interactiveConsole.lua
@@ -1,8 +1,5 @@
-module("interactiveConsole", package.seeall)
-
-setfenv(1, interactiveConsole);
-
-require(GetScriptDirectory().."/dota2comm")
+local interactiveConsole = {}
+local comm = require(GetScriptDirectory().."/dota2comm")
 
 function makestring(o, f)
     if (not f) then f={} end
@@ -59,8 +56,17 @@ function makestring(o, f)
     return res .. "}"
 end
 
-function execute()
-	local msg = comm.receive(); -- get a message
+function interactiveConsole:new(marker)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o.comm = comm:new(marker)
+    o.marker = marker
+    return o
+end
+
+function interactiveConsole:execute()
+	local msg = self.comm:receive(); -- get a message
     
     if msg == nil then -- if there wasn't one
 		return; -- don't do anything
@@ -69,7 +75,7 @@ function execute()
     local F = loadstring(msg) -- load function
     
     if (F == nil) then
-        comm.send("Syntax Error")
+        self.comm:send("Syntax Error")
         return
     end
     
@@ -81,5 +87,7 @@ function execute()
         result = "Error: " .. result; -- return the error
     end
     
-    comm.send(result); -- send the result
+    self.comm:send(result); -- send the result
 end
+
+return interactiveConsole

--- a/interactiveConsole/interactiveConsole.py
+++ b/interactiveConsole/interactiveConsole.py
@@ -4,34 +4,44 @@ from time import sleep
 
 from dota2comm import Dota2Comm
 
-if len(sys.argv) == 2:
-    dota = Dota2Comm(path=sys.argv[1])
-else:
-    dota = Dota2Comm()
+class InteractiveConsole():
+    def __init__(self, name):
+        self.name = name
+        self.dota = Dota2Comm(self.name)
+    
+    def StartThreads(self):
+        self.running = True
+        self.threadrecv = Thread(target=self.waitForAnswers)
+        self.threadrecv.start()
+        self.threadsend = Thread(target=self.sendRequests)
+        self.threadsend.start()
+    
+    def waitForAnswers(self):
+        while self.running:
+            msg = self.dota.receiveMessage()
+            if msg is not None:
+                print("%s: [Out] %s" % (self.name,str(msg)))
+            sleep(0.05)
+    
+    def sendRequests(self):
+        while self.running:
+            try:
+                print("%s: [In] " % (self.name), end="")
+                msg = input()
+                if msg == "exit":
+                    self.dota.exit()
+                    self.running = False
+                    self.threadrecv.join()
+                else:
+                    self.dota.sendMessage(msg)
+                sleep(0.1)
+            except:
+                self.running = False
+                sys.exit()
 
-def waitForAnswers():
-    while running:
-        msg = dota.receiveMessage()
-        if msg is not None:
-            print("[Out] %s" % str(msg))
-        sleep(0.05)
-    
-running = True
-    
-thread = Thread(target=waitForAnswers)
-thread.start()
-    
-while running:
-    try:
-        print("[In] ", end="")
-        msg = input()
-        if msg == "exit":
-            dota.exit()
-            running = False
-            thread.join()
-        else:
-            dota.sendMessage(msg)
-        sleep(0.1)
-    except:
-        running = False
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: ./interactiveConsole.py marker")
         sys.exit()
+    console = InteractiveConsole(sys.argv[1])
+    console.StartThreads()


### PR DESCRIPTION
The memory leak of dota2comm.dll continuously increase the mem of python.exe (from a few MB to 11GB)

The major issue of multi bots support is that the same string has only ONE instance in the memory.
Thus when two bots holding  the same string, for example: "is000". they are pointing the  same string with two different reference.

As a dirty solution, i just conjugate every string with a "unique" string.

I know these pull request will breaks a lot of your code, sry.

